### PR TITLE
Fix wrong intialized `ActiveLow` state

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub struct DebouncedInputPin<T: InputPin, A> {
     /// The counter.
     counter: i8,
 
-    /// The debounced state.
+    /// The debounced pin state.
     state: bool,
 }
 
@@ -82,13 +82,13 @@ impl<T: InputPin> DebouncedInputPin<T, ActiveLow> {
     pub fn update(&mut self) -> Result<(), <DebouncedInputPin<T, ActiveLow> as InputPin>::Error> {
         if self.pin.is_high()? {
             self.counter = 0;
-            self.state = false;
+            self.state = true;
         } else if self.counter < 10 {
             self.counter += 1;
         }
 
         if self.counter == 10 {
-            self.state = true;
+            self.state = false;
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Adds a wrapper for an `InputPin` that debounces it's `is_high()` and `is_low()` methods.
 
-#![cfg_attr(not(test), no_std)]
+#![no_std]
 
 use core::marker::PhantomData;
 use embedded_hal::digital::v2::InputPin;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,16 @@ impl<T: InputPin, A> InputPin for DebouncedInputPin<T, A> {
 }
 
 impl<T: InputPin> DebouncedInputPin<T, ActiveHigh> {
+    /// Initializes a new `ActiveHigh` debounced input pin.
+    pub fn active_high(pin: T) -> Self {
+        Self {
+            pin,
+            activeness: PhantomData,
+            counter: 0,
+            state: false,
+        }
+    }
+
     /// Updates the debounce logic.
     ///
     /// Needs to be called every ~1ms.
@@ -76,6 +86,15 @@ impl<T: InputPin> DebouncedInputPin<T, ActiveHigh> {
 }
 
 impl<T: InputPin> DebouncedInputPin<T, ActiveLow> {
+    /// Initializes a new `ActiveLow` debounced input pin.
+    pub fn active_low(pin: T) -> Self {
+        Self {
+            pin,
+            activeness: PhantomData,
+            counter: 0,
+            state: true,
+        }
+    }
     /// Updates the debounce logic.
     ///
     /// Needs to be called every ~1ms.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub struct DebouncedInputPin<T: InputPin, A> {
 impl<T: InputPin, A> DebouncedInputPin<T, A> {
     /// Initializes a new debounced input pin.
     pub fn new(pin: T, _activeness: A) -> Self {
-        DebouncedInputPin {
+        Self {
             pin,
             activeness: PhantomData,
             counter: 0,
@@ -59,7 +59,7 @@ impl<T: InputPin> DebouncedInputPin<T, ActiveHigh> {
     /// Updates the debounce logic.
     ///
     /// Needs to be called every ~1ms.
-    pub fn update(&mut self) -> Result<(), <DebouncedInputPin<T, ActiveHigh> as InputPin>::Error> {
+    pub fn update(&mut self) -> Result<(), <Self as InputPin>::Error> {
         if self.pin.is_low()? {
             self.counter = 0;
             self.state = false;
@@ -79,7 +79,7 @@ impl<T: InputPin> DebouncedInputPin<T, ActiveLow> {
     /// Updates the debounce logic.
     ///
     /// Needs to be called every ~1ms.
-    pub fn update(&mut self) -> Result<(), <DebouncedInputPin<T, ActiveLow> as InputPin>::Error> {
+    pub fn update(&mut self) -> Result<(), <Self as InputPin>::Error> {
         if self.pin.is_high()? {
             self.counter = 0;
             self.state = true;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,4 @@
 use crate::DebouncedInputPin;
-use common::*;
 use embedded_hal::digital::v2::InputPin;
 use failure::Fail;
 use mocks::*;
@@ -32,17 +31,6 @@ mod mocks {
     }
 }
 
-/// Shared functionallity for tests.
-mod common {
-    use super::*;
-
-    /// Creates a `DebouncedInputPin<MockInputPin, A>`.
-    pub fn create_pin<A>(activeness: A) -> DebouncedInputPin<MockInputPin, A> {
-        let pin = MockInputPin::default();
-        DebouncedInputPin::new(pin, activeness)
-    }
-}
-
 /// Tests for `DebouncedInputPin<T, A>`.
 mod input_pin {
     use super::*;
@@ -52,9 +40,15 @@ mod input_pin {
         use super::*;
         use crate::ActiveHigh; // Not importing `ActiveHigh` further up the chain to prevent mistakes.
 
+        /// Creates a `DebouncedInputPin<MockInputPin, A>`.
+        pub fn create_pin() -> DebouncedInputPin<MockInputPin, ActiveHigh> {
+            let pin = MockInputPin::default();
+            DebouncedInputPin::active_high(pin)
+        }
+
         #[test]
         fn it_updates_the_counter() -> Result<(), MockInputPinError> {
-            let mut pin = create_pin(ActiveHigh);
+            let mut pin = create_pin();
             pin.pin.state = true;
             assert_eq!(pin.counter, 0);
             pin.update()?;
@@ -64,7 +58,7 @@ mod input_pin {
 
         #[test]
         fn it_goes_high_when_counter_full() -> Result<(), MockInputPinError> {
-            let mut pin = create_pin(ActiveHigh);
+            let mut pin = create_pin();
             pin.pin.state = true;
             pin.counter = 10;
             assert!(pin.is_low()?);
@@ -76,7 +70,7 @@ mod input_pin {
 
         #[test]
         fn it_resets_the_counter_and_state_on_low() -> Result<(), MockInputPinError> {
-            let mut pin = create_pin(ActiveHigh);
+            let mut pin = create_pin();
             pin.pin.state = false;
             pin.counter = 10;
             pin.state = true;
@@ -89,7 +83,7 @@ mod input_pin {
 
         #[test]
         fn it_is_high_when_its_state_is_true_and_vice_versa() -> Result<(), MockInputPinError> {
-            let mut pin = create_pin(ActiveHigh);
+            let mut pin = create_pin();
             pin.state = true;
             assert_eq!(pin.is_high()?, pin.state);
             pin.state = false;
@@ -107,9 +101,15 @@ mod input_pin {
         use super::*;
         use crate::ActiveLow; // Not importing `ActiveLow` further up the chain to prevent mistakes.
 
+        /// Creates a `DebouncedInputPin<MockInputPin, A>`.
+        pub fn create_pin() -> DebouncedInputPin<MockInputPin, ActiveLow> {
+            let pin = MockInputPin::default();
+            DebouncedInputPin::active_low(pin)
+        }
+
         #[test]
         fn it_updates_the_counter() -> Result<(), MockInputPinError> {
-            let mut pin = create_pin(ActiveLow);
+            let mut pin = create_pin();
             pin.pin.state = false;
             assert_eq!(pin.counter, 0);
             pin.update()?;
@@ -119,7 +119,7 @@ mod input_pin {
 
         #[test]
         fn it_goes_low_when_counter_full() -> Result<(), MockInputPinError> {
-            let mut pin = create_pin(ActiveLow);
+            let mut pin = create_pin();
             pin.pin.state = false;
             pin.counter = 10;
             assert!(pin.is_high()?);
@@ -131,7 +131,7 @@ mod input_pin {
 
         #[test]
         fn it_resets_the_counter_and_state_on_high() -> Result<(), MockInputPinError> {
-            let mut pin = create_pin(ActiveLow);
+            let mut pin = create_pin();
             pin.pin.state = true;
             pin.counter = 10;
             pin.state = false;
@@ -144,7 +144,7 @@ mod input_pin {
 
         #[test]
         fn it_is_high_when_its_state_is_true_and_vice_versa() -> Result<(), MockInputPinError> {
-            let mut pin = create_pin(ActiveLow);
+            let mut pin = create_pin();
             pin.state = true;
             assert_eq!(pin.is_high()?, pin.state);
             pin.state = false;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -118,14 +118,14 @@ mod input_pin {
         }
 
         #[test]
-        fn it_goes_high_when_counter_full() -> Result<(), MockInputPinError> {
+        fn it_goes_low_when_counter_full() -> Result<(), MockInputPinError> {
             let mut pin = create_pin(ActiveLow);
             pin.pin.state = false;
             pin.counter = 10;
-            assert!(pin.is_low()?);
+            assert!(pin.is_high()?);
             pin.update()?;
             assert_eq!(pin.counter, 10);
-            assert!(pin.is_high()?);
+            assert!(pin.is_low()?);
             Ok(())
         }
 
@@ -134,10 +134,10 @@ mod input_pin {
             let mut pin = create_pin(ActiveLow);
             pin.pin.state = true;
             pin.counter = 10;
-            pin.state = true;
-            assert!(pin.is_high()?);
-            pin.update()?;
+            pin.state = false;
             assert!(pin.is_low()?);
+            pin.update()?;
+            assert!(pin.is_high()?);
             assert_eq!(pin.counter, 0);
             Ok(())
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,7 +9,7 @@ mod mocks {
     use super::*;
 
     #[derive(Debug, Fail)]
-    #[fail(display = "An error occured")]
+    #[fail(display = "An error occurred")]
     pub struct MockInputPinError;
 
     /// A mock implementation of `InputPin`.


### PR DESCRIPTION
I tried several method, like [this](https://github.com/Sh3Rm4n/rust-debounced-pin/blob/0660a2765106a2e01819af9e037c80826c376c04/src/lib.rs#L14) and I tried to duplicate the `new()` method for `ActiveLow` and `ActiveHigh`. But, as I am not experienced enough with rust I was not successful.

I came up with this solution and am quite happy with it. This split the `new()` method in two methods: 

`active_low()` and `active_high`. No argument which supplies the `ActiveX` type is needed anymore. 

Fix: https://github.com/Winseven4lyf/rust-debounced-pin/issues/1